### PR TITLE
Change livechat agent's default status to not-available

### DIFF
--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -466,7 +466,7 @@ RocketChat.Livechat = {
 
 		if (RocketChat.authz.addUserRoles(user._id, 'livechat-agent')) {
 			RocketChat.models.Users.setOperator(user._id, true);
-			RocketChat.models.Users.setLivechatStatus(user._id, 'available');
+			RocketChat.models.Users.setLivechatStatus(user._id, 'not-available');
 			return user;
 		}
 


### PR DESCRIPTION
Set the default status of a livechat agent to not-available.